### PR TITLE
Fixing the knowledge-base action to run on expectation

### DIFF
--- a/.github/workflows/knowledge-platform.yaml
+++ b/.github/workflows/knowledge-platform.yaml
@@ -10,7 +10,6 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This knowledge-base action should trigger on:

1) Any push to main (PR Merge or plain push)
